### PR TITLE
[table header] sticky table header and package anchor position change

### DIFF
--- a/html_reports/cross_index_update_report.css
+++ b/html_reports/cross_index_update_report.css
@@ -40,6 +40,11 @@ h2 a {
 
 a { color: #EE0000; /* RH */ }
 
+a.package-name {
+    padding-top: 135px;
+    margin-top: -135px
+}
+
 .blue { color: #023D4F;  /* RH */}
 .yellow { color: #FFF842; }
 
@@ -88,6 +93,11 @@ a { color: #EE0000; /* RH */ }
 .container th {
     /*background-color: #1F2739;*/
     box-shadow: 0 2px 2px -2px #0e1119;
+
+    position: sticky;
+    top: 0px;
+    background-color: rgba(255, 255, 255, 0.9);
+    z-index: 999;
 }
 
 .container td:first-child { color: #EE0000; /* RH */ }


### PR DESCRIPTION
Make the table header sticky when scrolling and add a class for package name anchor link position so it works better with the sticky table header.

Make the table header sticky when scrolling and add a class for package name anchor link position so it works better with the sticky table header.

**1. sticky table header**
![1_sticky_table_header](https://user-images.githubusercontent.com/5903705/185983591-154e7db3-fd15-46df-9673-5259305ff401.png)

**2. package anchor position tweaks**
![2_anchor_link_vertical_position](https://user-images.githubusercontent.com/5903705/185983661-18257ac4-a722-456d-b503-528afd186214.png)
