### PR TITLE
[table header] fix sticky header not working for Chrome, Brave, and Safari

### DIFF
--- a/html_reports/cross_index_update_report.css
+++ b/html_reports/cross_index_update_report.css
@@ -65,7 +65,6 @@ a.package-name {
 
 .container {
     text-align: left;
-    overflow: hidden;
     width: 80%;
     margin: 0 auto;
   display: table;
@@ -94,6 +93,10 @@ a.package-name {
     /*background-color: #1F2739;*/
     box-shadow: 0 2px 2px -2px #0e1119;
 
+    position: -webkit-sticky;
+    position: -moz-sticky;
+    position: -ms-sticky;
+    position: -o-sticky;
     position: sticky;
     top: 0px;
     background-color: rgba(255, 255, 255, 0.9);


### PR DESCRIPTION
Remove container overflow: hidden for sticky header